### PR TITLE
Slowly increase `count` as new particles are spawned

### DIFF
--- a/packages/vfx-composer/src/ParticleAttribute.ts
+++ b/packages/vfx-composer/src/ParticleAttribute.ts
@@ -36,7 +36,7 @@ export const ParticleAttribute = <
 
     isParticleAttribute: true,
 
-    setupMesh: ({ geometry, count }: InstancedMesh) => {
+    setupMesh: ({ geometry, capacity, safetyCapacity }: Particles) => {
       const itemSize =
         type === "float"
           ? 1
@@ -48,7 +48,10 @@ export const ParticleAttribute = <
           ? 4
           : 4
 
-      geometry.setAttribute(name, makeAttribute(count, itemSize))
+      geometry.setAttribute(
+        name,
+        makeAttribute(capacity + safetyCapacity, itemSize)
+      )
     },
 
     get value() {

--- a/packages/vfx-composer/src/Particles.ts
+++ b/packages/vfx-composer/src/Particles.ts
@@ -47,9 +47,13 @@ export class Particles extends InstancedMesh<BufferGeometry> {
     super(geometry, material, capacity + safetyCapacity)
     this.capacity = capacity
     this.safetyCapacity = safetyCapacity
+    this.count = 0
 
     this.onBeforeRender = () => {
       const emitted = this.cursor - this.lastCursor
+
+      /* Increase total count of particles if we haven't done so before. */
+      this.count = Math.max(this.count, this.cursor)
 
       if (emitted > 0) {
         this.uploadableAttributes.forEach((attribute) => {


### PR DESCRIPTION
This is a small optimiziation that allows high-capacity particle meshes to "ramp up" their instance count as new particles are spawned.

Fixes #174