### PR TITLE
Improve Controlled Particles

### DIFF
--- a/apps/vfx-composer-examples/src/examples/ControlledParticles.tsx
+++ b/apps/vfx-composer-examples/src/examples/ControlledParticles.tsx
@@ -12,7 +12,7 @@ export default function ControlledParticlesExample() {
       Math.sin(clock.elapsedTime * 1.7),
       0
     )
-  })
+  }, -100)
 
   return (
     <group>

--- a/packages/vfx-composer-r3f/package.json
+++ b/packages/vfx-composer-r3f/package.json
@@ -27,6 +27,7 @@
     "@hmans/use-rerender": "^0.0.2",
     "@hmans/use-version": "^0.0.2",
     "material-composer-r3f": "^0.2.2",
+    "miniplex": "^0.10.5",
     "shader-composer": "^0.4.1",
     "shader-composer-r3f": "^0.4.0",
     "vfx-composer": "^0.2.4"

--- a/packages/vfx-composer-r3f/src/Emitter.tsx
+++ b/packages/vfx-composer-r3f/src/Emitter.tsx
@@ -28,7 +28,7 @@ export const Emitter = forwardRef<Object3D, EmitterProps>(
     ref
   ) => {
     const origin = useRef<Object3D>(null!)
-    const particlesFromContext = useParticlesContext()
+    const context = useParticlesContext()
     const queuedParticles = useRef(0)
     const remainingParticles = useRef(limit)
     const particlesMatrix = useRef(new Matrix4())
@@ -57,7 +57,7 @@ export const Emitter = forwardRef<Object3D, EmitterProps>(
     /* When the particle material has changed, reset this emitter. (HMR) */
     useFrameEffect(
       () => {
-        const particles = particlesProp?.current || particlesFromContext
+        const particles = particlesProp?.current || context.particles
         return particles?.material
       },
       () => {
@@ -76,7 +76,7 @@ export const Emitter = forwardRef<Object3D, EmitterProps>(
         if (remainingParticles.current <= 0) return
 
         /* Grab a reference to the particles mesh */
-        const particles = particlesProp?.current || particlesFromContext
+        const particles = particlesProp?.current || context.particles
         if (!particles) return
 
         /* Increase the accumulated number of particles we're supposed to emit. */
@@ -104,7 +104,7 @@ export const Emitter = forwardRef<Object3D, EmitterProps>(
           remainingParticles.current -= amount
         }
       },
-      [particlesProp, particlesFromContext, emitterSetup, rate, limit]
+      [particlesProp, context?.particles, emitterSetup, rate, limit]
     )
 
     useFrame((_, dt) => {

--- a/packages/vfx-composer-r3f/src/Particle.tsx
+++ b/packages/vfx-composer-r3f/src/Particle.tsx
@@ -22,7 +22,7 @@ const tmpMatrix = new Matrix4()
  */
 export const Particle = forwardRef<Object3D, Object3DProps>((props, ref) => {
   const sceneObject = useRef<Object3D>(null!)
-  const { particles } = useParticlesContext()
+  const { particles, ecs } = useParticlesContext()
   const id = useRef<number>()
 
   useLayoutEffect(() => {
@@ -33,25 +33,18 @@ export const Particle = forwardRef<Object3D, Object3DProps>((props, ref) => {
     /* Emit the particle */
     particles.emit(1)
 
+    /* Register with ECS */
+    const entity = ecs.createEntity({
+      id: cursor,
+      sceneObject: sceneObject.current
+    })
+
     /* Hide the particle again on unmount */
     return () => {
+      ecs.destroyEntity(entity)
       particles.setMatrixAt(cursor, hideMatrix)
     }
   }, [particles])
-
-  /* Every frame, update the particle's matrix, and queue a re-upload */
-  useFrame(() => {
-    if (id.current === undefined) return
-
-    particles.setMatrixAt(
-      id.current,
-      tmpMatrix
-        .copy(sceneObject.current.matrixWorld)
-        .premultiply(particles.matrixWorld.invert())
-    )
-
-    particles.instanceMatrix.needsUpdate = true
-  })
 
   /* Forward the ref */
   useImperativeHandle(ref, () => sceneObject.current)

--- a/packages/vfx-composer-r3f/src/Particle.tsx
+++ b/packages/vfx-composer-r3f/src/Particle.tsx
@@ -22,7 +22,7 @@ const tmpMatrix = new Matrix4()
  */
 export const Particle = forwardRef<Object3D, Object3DProps>((props, ref) => {
   const sceneObject = useRef<Object3D>(null!)
-  const particles = useParticlesContext()
+  const { particles } = useParticlesContext()
   const id = useRef<number>()
 
   useLayoutEffect(() => {

--- a/packages/vfx-composer-r3f/src/Particle.tsx
+++ b/packages/vfx-composer-r3f/src/Particle.tsx
@@ -25,12 +25,15 @@ export const Particle = forwardRef<Object3D, Object3DProps>((props, ref) => {
   const particles = useParticlesContext()
   const id = useRef<number>()
 
-  /* Hide the particle again on unmount */
   useLayoutEffect(() => {
+    /* Store the particle's ID */
     const cursor = particles.cursor
     id.current = cursor
+
+    /* Emit the particle */
     particles.emit(1)
 
+    /* Hide the particle again on unmount */
     return () => {
       particles.setMatrixAt(cursor, hideMatrix)
     }

--- a/packages/vfx-composer-r3f/src/Particles.tsx
+++ b/packages/vfx-composer-r3f/src/Particles.tsx
@@ -1,6 +1,7 @@
 import { useConst } from "@hmans/use-const"
 import { InstancedMeshProps, useFrame } from "@react-three/fiber"
 import { getShaderRootForMaterial } from "material-composer-r3f"
+import { World } from "miniplex"
 import React, {
   createContext,
   forwardRef,
@@ -12,7 +13,6 @@ import React, {
 import { Material, Matrix4, Object3D } from "three"
 import { Particles as ParticlesImpl } from "vfx-composer"
 import { useFrameEffect } from "./lib/useFrameEffect"
-import { World } from "miniplex"
 
 const tmpMatrix = new Matrix4()
 
@@ -25,6 +25,7 @@ export type ParticlesProps = Omit<
   material?: Material
   capacity?: number
   safetyCapacity?: number
+  updatePriority?: number
 }
 
 export type Entity = {
@@ -40,7 +41,15 @@ export const useParticlesContext = () => useContext(Context)
 
 export const Particles = forwardRef<ParticlesImpl, ParticlesProps>(
   (
-    { children, capacity, safetyCapacity, geometry, material, ...props },
+    {
+      children,
+      capacity,
+      safetyCapacity,
+      geometry,
+      material,
+      updatePriority,
+      ...props
+    },
     ref
   ) => {
     /* The Particles instance this component is managing. */
@@ -88,7 +97,7 @@ export const Particles = forwardRef<ParticlesImpl, ParticlesProps>(
 
       /* Queue a re-upload */
       particles.instanceMatrix.needsUpdate = true
-    })
+    }, updatePriority)
 
     /* Dispose of the particles instance on unmount */
     useLayoutEffect(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,6 +859,7 @@ importers:
       '@hmans/use-version': ^0.0.2
       '@react-three/fiber': ^8.7.0
       material-composer-r3f: ^0.2.2
+      miniplex: ^0.10.5
       react: ^18.2.0
       react-dom: ^18.2.0
       shader-composer: ^0.4.1
@@ -870,6 +871,7 @@ importers:
       '@hmans/use-rerender': 0.0.2_react@18.2.0
       '@hmans/use-version': 0.0.2_react@18.2.0
       material-composer-r3f: link:../material-composer-r3f
+      miniplex: 0.10.5
       shader-composer: link:../shader-composer
       shader-composer-r3f: link:../shader-composer-r3f
       vfx-composer: link:../vfx-composer
@@ -2708,6 +2710,10 @@ packages:
 
   /@hmans/signal/0.1.8:
     resolution: {integrity: sha512-jhTe89A0Fzp0aRcQdB1F9Z1gDqFNFS5kZohbk/EiQqvcVJqfJ5XG0IsSEZiyAT7RuiLXupwbAn7MxXVL+iZZIA==}
+    dev: false
+
+  /@hmans/signal/0.2.2:
+    resolution: {integrity: sha512-4KlR6FiqICOY9J8V483Atk7bfMqoGM/hdYd/6ab+HB+CJfiOBPzY6PtYz3O6bBsNkIZpimnTMSw2AqOz1WDlrA==}
     dev: false
 
   /@hmans/things/0.0.4_hutetxkntliphjz5jo5ozlmmu4:
@@ -8894,6 +8900,12 @@ packages:
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: false
+
+  /miniplex/0.10.5:
+    resolution: {integrity: sha512-ldfZHviVJ9uJfp0UriVXlO+6iv4u+j5oQPltLKpAjuQK0xShssRG14JEoDJRz4CV+st7rw6krc2lvY4m3452Cg==}
+    dependencies:
+      '@hmans/signal': 0.2.2
     dev: false
 
   /mixin-deep/1.3.2:


### PR DESCRIPTION
This changes the implementation of `<Particle>` to instead having its own `useFrame`, it registers itself with a small ECS contained in the `<Particles>` parent component, which will iterate through the registered controlled particles to update their matrices.