### PR TITLE
export full name math helpers

### DIFF
--- a/.changeset/violet-apes-end.md
+++ b/.changeset/violet-apes-end.md
@@ -1,0 +1,5 @@
+---
+"shader-composer": minor
+---
+
+Export additional full name Divide, Multiply,and Subtract math helpers.

--- a/.changeset/violet-apes-end.md
+++ b/.changeset/violet-apes-end.md
@@ -2,4 +2,4 @@
 "shader-composer": minor
 ---
 
-Export additional full name Divide, Multiply,and Subtract math helpers.
+**New:** Additional full name `Divide`, `Multiply`, and `Subtract` math helpers, aliased to `Div`, `Mul` and `Sub`, respectively.

--- a/packages/shader-composer/src/stdlib/math.ts
+++ b/packages/shader-composer/src/stdlib/math.ts
@@ -35,15 +35,21 @@ export const Add = Operator("Add", "+")
  */
 export const Sub = Operator("Subtract", "-")
 
+export const Subtract = Sub
+
 /**
  * A Shader Unit that multiplies two values and returns the result.
  */
 export const Mul = Operator("Multiply", "*")
 
+export const Multiply = Mul
+
 /**
  * A Shader Unit that divides two values and returns the result.
  */
 export const Div = Operator("Divide", "/")
+
+export const Divide = Div
 
 /**
  * Calculates the sine value of the input value.


### PR DESCRIPTION
I just did a simple rename in VS Code for Div, Mul, and Sub. Would you rather me add additional Divide, Multiply, Subtract exports on top of the existing?

closes #349