### PR TITLE
Improve time synchronization across multiple shaders

### DIFF
--- a/apps/vfx-composer-examples/src/examples/Playground.tsx
+++ b/apps/vfx-composer-examples/src/examples/Playground.tsx
@@ -1,14 +1,55 @@
 import { composable, modules } from "material-composer-r3f"
-import { Mul, Time } from "shader-composer"
+import { GlobalTime, Mul, NormalizePlusMinusOne, Sin } from "shader-composer"
 import { Color } from "three"
 
 export default function Playground() {
   return (
     <group>
-      <mesh>
+      <mesh position-x={-2}>
         <sphereGeometry />
         <composable.meshStandardMaterial>
-          <modules.Color color={Mul(new Color("hotpink"), Time())} />
+          <modules.Color
+            color={Mul(
+              new Color("hotpink"),
+              NormalizePlusMinusOne(Sin(GlobalTime))
+            )}
+          />
+        </composable.meshStandardMaterial>
+      </mesh>
+
+      <mesh position-x={2}>
+        <sphereGeometry />
+        <composable.meshStandardMaterial>
+          <modules.Color
+            color={Mul(
+              new Color("cyan"),
+              NormalizePlusMinusOne(Sin(GlobalTime))
+            )}
+          />
+        </composable.meshStandardMaterial>
+      </mesh>
+
+      <mesh position-y={2}>
+        <sphereGeometry />
+        <composable.meshStandardMaterial>
+          <modules.Color
+            color={Mul(
+              new Color("red"),
+              NormalizePlusMinusOne(Sin(GlobalTime))
+            )}
+          />
+        </composable.meshStandardMaterial>
+      </mesh>
+
+      <mesh position-y={-2}>
+        <sphereGeometry />
+        <composable.meshStandardMaterial>
+          <modules.Color
+            color={Mul(
+              new Color("white"),
+              NormalizePlusMinusOne(Sin(GlobalTime))
+            )}
+          />
         </composable.meshStandardMaterial>
       </mesh>
     </group>

--- a/packages/shader-composer-core/src/compiler.ts
+++ b/packages/shader-composer-core/src/compiler.ts
@@ -236,7 +236,7 @@ export const compileShader = (root: Unit) => {
   /*
   STEP 5: Collect update callbacks.
   */
-  const unitsWithUpdates = collectFromTree(
+  const unitsWithUpdates: Unit[] = collectFromTree(
     root,
     "any",
     (item) => isUnit(item) && !!item._unitConfig.update
@@ -247,13 +247,14 @@ export const compileShader = (root: Unit) => {
   */
   const update = (dt: number, payload?: any) => {
     const now = performance.now()
+    const ctx = { dt, time: now / 1000 }
 
     for (const unit of unitsWithUpdates) {
       const state = unit._unitState
 
       /* Only invoke the update callback once per frame. */
       if (state.lastUpdateAt === undefined || state.lastUpdateAt < now) {
-        unit._unitConfig.update(dt, payload)
+        unit._unitConfig.update!(ctx, payload)
         state.lastUpdateAt = now
       }
     }

--- a/packages/shader-composer-core/src/compiler.ts
+++ b/packages/shader-composer-core/src/compiler.ts
@@ -3,7 +3,14 @@ import { Expression } from "./expressions"
 import { glslRepresentation } from "./glslRepresentation"
 import { isSnippet, renameSnippet, Snippet } from "./snippets"
 import { collectFromTree, Item, walkTree } from "./tree"
-import { isUnit, isUnitInProgram, Program, uniformName, Unit } from "./units"
+import {
+  isUnit,
+  isUnitInProgram,
+  Program,
+  uniformName,
+  Unit,
+  UpdateContext
+} from "./units"
 import {
   assignment,
   block,
@@ -245,17 +252,14 @@ export const compileShader = (root: Unit) => {
   /*
   STEP 6: Build per-frame update function.
   */
-  const update = (dt: number, payload?: any) => {
-    const now = performance.now()
-    const ctx = { dt, time: now / 1000 }
-
+  const update = (ctx: UpdateContext, payload?: any) => {
     for (const unit of unitsWithUpdates) {
       const state = unit._unitState
 
       /* Only invoke the update callback once per frame. */
-      if (state.lastUpdateAt === undefined || state.lastUpdateAt < now) {
+      if (state.lastUpdateAt === undefined || state.lastUpdateAt < ctx.time) {
         unit._unitConfig.update!(ctx, payload)
-        state.lastUpdateAt = now
+        state.lastUpdateAt = ctx.time
       }
     }
   }

--- a/packages/shader-composer-core/src/stdlib/variables.ts
+++ b/packages/shader-composer-core/src/stdlib/variables.ts
@@ -164,7 +164,7 @@ export const Time = (initial: number = 0) => {
   const uniform = UniformUnit("float", initial, {
     name: "Time Uniform",
 
-    update: (dt) => {
+    update: ({ dt }) => {
       uniform.value += dt
     }
   })

--- a/packages/shader-composer-core/src/units.ts
+++ b/packages/shader-composer-core/src/units.ts
@@ -42,7 +42,12 @@ export type JSTypes = {
 
 export type Input<T extends GLSLType = any> = Expression | JSTypes[T] | Unit<T>
 
-export type UpdateCallback = (dt: number, payload?: any) => void
+export type UpdateContext = {
+  dt: number
+  time: number
+}
+
+export type UpdateCallback = (ctx: UpdateContext, payload?: any) => void
 
 export type UnitConfig<T extends GLSLType> = {
   /**

--- a/packages/shader-composer-r3f/src/hooks.ts
+++ b/packages/shader-composer-r3f/src/hooks.ts
@@ -19,8 +19,8 @@ export const useShader = (ctor: () => Unit, deps?: any) => {
   useEffect(() => () => dispose(), deps)
 
   /* Invoke the shader tree's update functions. */
-  useFrame(function useShaderUpdate({ camera, scene, gl }, dt) {
-    update(dt, { camera, scene, gl })
+  useFrame(function useShaderUpdate({ clock, camera, scene, gl }, dt) {
+    update({ dt, time: clock.oldTime }, { camera, scene, gl })
   })
 
   return shader


### PR DESCRIPTION
- Instead of only passing a delta time to unit update callbacks, we now pass a context object containing both the delta time _and_ an absolute time value.
- This absolute time value is expected _to remain the same within any given frame_.
- This time value is used to ensure that units used across multiple shader graphs (like `GlobalTime`) only ever run _once_ per frame, and not once for every frame.
- For the r3f bindings, we use `clock.oldTime` to fill this.

Issues fixed by this change:

- #361